### PR TITLE
Fixes NodeCount() to return count of schedulable nodes only

### DIFF
--- a/pkg/kuberang/kubectlparser.go
+++ b/pkg/kuberang/kubectlparser.go
@@ -111,11 +111,21 @@ type PodsResponse struct {
 }
 
 type NodeResponse struct {
-	Items []interface{} `json:"items"`
+	Items []struct {
+		Spec struct {
+			Unschedulable bool `json:"unschedulable,omitempty"`
+		} `json:"spec"`
+	} `json:"items"`
 }
 
 func (ko KubeOutput) NodeCount() int {
 	resp := NodeResponse{}
 	json.Unmarshal(ko.RawOut, &resp)
-	return len(resp.Items)
+	count := 0
+	for _, item := range resp.Items {
+		if item.Spec.Unschedulable == false {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/kuberang/kubectlparser_test.go
+++ b/pkg/kuberang/kubectlparser_test.go
@@ -9,8 +9,8 @@ func TestNodeCount(t *testing.T) {
 		CombinedOut: SampleNodeRespones,
 		RawOut:      []byte(SampleNodeRespones),
 	}
-	if nodesCount := ko.NodeCount(); nodesCount != 4 {
-		t.Errorf("Wrong number of nodes, expeted 4, got %d", nodesCount)
+	if nodesCount := ko.NodeCount(); nodesCount != 3 {
+		t.Errorf("Wrong number of nodes, expeted 3, got %d", nodesCount)
 	}
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/apprenda/kuberang/issues/13. 

Feedback / comments welcome.