### PR TITLE
Add JSON output format

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -8,24 +8,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewKismaticCommand creates the kismatic command
+// NewKuberangCommand creates the kuberang command
 func NewKuberangCommand(version string, in io.Reader, out io.Writer) *cobra.Command {
+	var outputFormat string
 	cmd := &cobra.Command{
 		Use:   "kuberang",
 		Short: "kuberang tests your kubernetes cluster using kubectl",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doCheckKubernetes(args)
+			return doCheckKubernetes(outputFormat)
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-
-	cmd.PersistentFlags().StringVarP(&config.Namespace, "namespace", "n", "", 
+	cmd.PersistentFlags().StringVarP(&config.Namespace, "namespace", "n", "",
 		"Kubernetes namespace in which kuberang will operate. Defaults to 'default' if not specified.")
-
+	cmd.Flags().StringVarP(&outputFormat, "output-format", "o", "simple", "set the output format. One of: simple|json")
 	return cmd
 }
 
-func doCheckKubernetes(args []string) error {
-	return kuberang.CheckKubernetes()
+func doCheckKubernetes(outputFormat string) error {
+	return kuberang.CheckKubernetes(outputFormat)
 }

--- a/pkg/kuberang/report.go
+++ b/pkg/kuberang/report.go
@@ -1,0 +1,70 @@
+package kuberang
+
+import (
+	"io"
+
+	"github.com/apprenda/kuberang/pkg/util"
+)
+
+type report interface {
+	addSuccess(string)
+	addIgnored(string)
+	addError(string)
+	isSuccess() bool
+}
+
+// CheckResult contains the results from executing a check in Kuberang
+type CheckResult struct {
+	Name    string
+	Success bool
+	Ignored bool
+}
+
+type simpleReport struct {
+	CheckResults []CheckResult
+}
+
+func (r *simpleReport) isSuccess() bool {
+	for _, c := range r.CheckResults {
+		if !c.Success && !c.Ignored { // return false if a check failed and is not ignored
+			return false
+		}
+	}
+	return true
+}
+
+func (r *simpleReport) addSuccess(name string) {
+	r.CheckResults = append(r.CheckResults, CheckResult{Name: name, Success: true})
+}
+
+func (r *simpleReport) addError(name string) {
+	r.CheckResults = append(r.CheckResults, CheckResult{Name: name, Success: true})
+}
+
+func (r *simpleReport) addIgnored(name string) {
+	r.CheckResults = append(r.CheckResults, CheckResult{Name: name, Success: false, Ignored: true})
+}
+
+type echoReport struct {
+	report simpleReport
+	out    io.Writer
+}
+
+func (r *echoReport) addSuccess(name string) {
+	r.report.addSuccess(name)
+	util.PrettyPrintOk(r.out, name)
+}
+
+func (r *echoReport) addError(name string) {
+	r.report.addError(name)
+	util.PrettyPrintErr(r.out, name)
+}
+
+func (r *echoReport) addIgnored(name string) {
+	r.report.addIgnored(name)
+	util.PrettyPrintErrorIgnored(r.out, name)
+}
+
+func (r *echoReport) isSuccess() bool {
+	return r.report.isSuccess()
+}

--- a/pkg/kuberang/report_test.go
+++ b/pkg/kuberang/report_test.go
@@ -1,0 +1,92 @@
+package kuberang
+
+import "testing"
+
+func TestSimpleReportIsSuccess(t *testing.T) {
+	tests := []struct {
+		name          string
+		results       []CheckResult
+		expectSuccess bool
+	}{
+		{
+			name: "one successful",
+			results: []CheckResult{
+				{
+					Success: true,
+					Ignored: false,
+				},
+			},
+			expectSuccess: true,
+		},
+		{
+			name: "one failure",
+			results: []CheckResult{
+				{
+					Success: false,
+					Ignored: false,
+				},
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "one ignored failure",
+			results: []CheckResult{
+				{
+					Success: false,
+					Ignored: true,
+				},
+			},
+			expectSuccess: true,
+		},
+		{
+			name: "one success, one failure",
+			results: []CheckResult{
+				{
+					Success: true,
+				},
+				{
+					Success: false,
+				},
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "one failure, one ignored failure",
+			results: []CheckResult{
+				{
+					Success: false,
+				},
+				{
+					Success: false,
+					Ignored: true,
+				},
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "one failure, one ignored failure, one success",
+			results: []CheckResult{
+				{
+					Success: false,
+				},
+				{
+					Success: false,
+					Ignored: true,
+				},
+				{
+					Success: true,
+				},
+			},
+			expectSuccess: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			report := simpleReport{CheckResults: test.results}
+			success := report.isSuccess()
+			if success != test.expectSuccess {
+				t.Errorf("Expected %v, but got %v", test.expectSuccess, success)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for printing JSON to the console, instead of the table format. (Fixes #5 )

The main change is the introduction of a `report`, which can be populated with successes, errors, and ignored errors. The `report` itself is considered successful if there are no errors.

There are two implementations of `report`:
* simpleReport: the simple report just stores results in memory, and is serialized to JSON at the end of the workflow.
* echoReport: the echo report is similar to the simpleReport, but it also prints messages to the screen as items are added.

The following is a sample of a happy path report:
```
./kuberang -o json
{
    "CheckResults": [
        {
            "Name": "Configured kubectl exists",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Nginx service does not already exist",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "BusyBox service does not already exist",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Nginx service does not already exist",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Issued BusyBox start request",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Issued Nginx start request",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Both deployments completed successfully within timeout",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Issued expose Nginx service request",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Grab nginx pod ip addresses",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Grab nginx service ip address",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Grab BusyBox pod name",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Accessed Nginx service at 172.17.119.10 from BusyBox",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Accessed Nginx service via DNS kuberang-nginx-1481031653201225236 from BusyBox",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Accessed Nginx pod at 172.16.0.7 from BusyBox",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Accessed Nginx pod at 172.16.114.7 from BusyBox",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Accessed Google.com from BusyBox",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Accessed Nginx service via DNS kuberang-nginx-1481031653201225236 from this node",
            "Success": false,
            "Ignored": true
        },
        {
            "Name": "Accessed Nginx pod at 172.16.0.7 from this node",
            "Success": false,
            "Ignored": true
        },
        {
            "Name": "Accessed Nginx pod at 172.16.114.7 from this node",
            "Success": false,
            "Ignored": true
        },
        {
            "Name": "Accessed Google.com from this node",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Powered down Nginx service",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Powered down Busybox deployment",
            "Success": true,
            "Ignored": false
        },
        {
            "Name": "Powered down Nginx deployment",
            "Success": true,
            "Ignored": false
        }
    ]
}
```