### PR TITLE
Add support for skipping cleanup

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -10,11 +10,12 @@ import (
 
 // NewKismaticCommand creates the kismatic command
 func NewKuberangCommand(version string, in io.Reader, out io.Writer) *cobra.Command {
+	var skipCleanup bool
 	cmd := &cobra.Command{
 		Use:   "kuberang",
 		Short: "kuberang tests your kubernetes cluster using kubectl",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doCheckKubernetes(args)
+			return doCheckKubernetes(skipCleanup)
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -24,10 +25,11 @@ func NewKuberangCommand(version string, in io.Reader, out io.Writer) *cobra.Comm
 		"Kubernetes namespace in which kuberang will operate. Defaults to 'default' if not specified.")
 	cmd.PersistentFlags().StringVar(&config.RegistryURL, "registry-url", "",
 		"Override the default Docker Hub URL to use a local offline registry for required Docker images.")
+	cmd.Flags().BoolVar(&skipCleanup, "skip-cleanup", false, "Don't clean up. Leave all deployed artifacts running on the cluster.")
 
 	return cmd
 }
 
-func doCheckKubernetes(args []string) error {
-	return kuberang.CheckKubernetes()
+func doCheckKubernetes(skipCleanup bool) error {
+	return kuberang.CheckKubernetes(skipCleanup)
 }

--- a/pkg/kuberang/mainworkflow.go
+++ b/pkg/kuberang/mainworkflow.go
@@ -21,7 +21,7 @@ const (
 	httpTimeout              = 1000 * time.Millisecond
 )
 
-func CheckKubernetes() error {
+func CheckKubernetes(skipCleanup bool) error {
 	out := os.Stdout
 	ngServiceName := nginxServiceName()
 	if !precheckKubectl() ||
@@ -163,7 +163,9 @@ func CheckKubernetes() error {
 		util.PrettyPrintErrorIgnored(out, "Accessed Google.com from this node")
 	}
 
-	powerDown(ngServiceName)
+	if !skipCleanup {
+		powerDown(ngServiceName)
+	}
 
 	if success {
 		return nil


### PR DESCRIPTION
This is useful when you've seen kuberang fail, and you'd like to leave the pods running to do some troubleshooting.

Usage: `./kuberang --skip-cleanup`