### PR TITLE
Display more information when a failure occurs

### DIFF
--- a/pkg/kuberang/mainworkflow.go
+++ b/pkg/kuberang/mainworkflow.go
@@ -2,6 +2,7 @@ package kuberang
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -17,10 +18,11 @@ const (
 	bbDeploymentName         = runPrefix + "busybox"
 	ngDeploymentName         = runPrefix + "nginx"
 	deploymentTimeoutSeconds = 300 //seconds
-	httpTimeoutMillis        = 1000 * time.Millisecond
+	httpTimeout              = 1000 * time.Millisecond
 )
 
 func CheckKubernetes() error {
+	out := os.Stdout
 	ngServiceName := nginxServiceName()
 	if !precheckKubectl() ||
 		!precheckNamespace() ||
@@ -35,21 +37,22 @@ func CheckKubernetes() error {
 	// Scale out busybox
 	busyboxCount := int64(1)
 	if ko := RunKubectl("run", bbDeploymentName, "--image=busybox", "--image-pull-policy=IfNotPresent", "--", "sleep", "3600"); !ko.Success {
-		util.PrettyPrintErr(os.Stdout, "Issued BusyBox start request")
-		fmt.Fprintf(os.Stdout, "- error: %v", ko.CombinedOut)
+		util.PrettyPrintErr(out, "Issued BusyBox start request")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	} else {
-		util.PrettyPrintOk(os.Stdout, "Issued BusyBox start request")
+		util.PrettyPrintOk(out, "Issued BusyBox start request")
 	}
 	// Scale out nginx
 	// Try to run a Pod on each Node,
 	// This scheduling is not guaranteed but it gets close
 	nginxCount := int64(RunGetNodes().NodeCount())
 	if ko := RunPod(ngDeploymentName, "nginx", nginxCount); !ko.Success {
-		util.PrettyPrintErr(os.Stdout, "Issued Nginx start request")
+		util.PrettyPrintErr(out, "Issued Nginx start request")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	} else {
-		util.PrettyPrintOk(os.Stdout, "Issued Nginx start request")
+		util.PrettyPrintOk(out, "Issued Nginx start request")
 	}
 
 	// Check for both
@@ -59,10 +62,11 @@ func CheckKubernetes() error {
 
 	// Add service
 	if ko := RunKubectl("expose", "deployment", ngDeploymentName, "--name="+ngServiceName, "--port=80"); !ko.Success {
-		util.PrettyPrintErr(os.Stdout, "Issued expose Nginx service request")
+		util.PrettyPrintErr(out, "Issued expose Nginx service request")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	} else {
-		util.PrettyPrintOk(os.Stdout, "Issued expose Nginx service request")
+		util.PrettyPrintOk(out, "Issued expose Nginx service request")
 	}
 
 	// Get pod & service IPs
@@ -71,82 +75,88 @@ func CheckKubernetes() error {
 	var busyboxPodName string
 	if ko := RunKubectl("get", "pods", "-l", "run=kuberang-nginx", "-o", "json"); ko.Success {
 		podIPs = ko.PodIPs()
-		util.PrettyPrintOk(os.Stdout, "Grab nginx pod ip addresses")
+		util.PrettyPrintOk(out, "Grab nginx pod ip addresses")
 	} else {
 		podIPs = make([]string, 0)
-		util.PrettyPrintErr(os.Stdout, "Grab nginx pod ip addresses")
+		util.PrettyPrintErr(out, "Grab nginx pod ip addresses")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
 	if ko := RunGetService(ngServiceName); ko.Success {
 		serviceIP = ko.ServiceCluserIP()
-		util.PrettyPrintOk(os.Stdout, "Grab nginx service ip address")
+		util.PrettyPrintOk(out, "Grab nginx service ip address")
 	} else {
 		serviceIP = ""
-		util.PrettyPrintErr(os.Stdout, "Grab nginx service ip address")
+		util.PrettyPrintErr(out, "Grab nginx service ip address")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
 	if ko := RunKubectl("get", "pods", "-l", "run=kuberang-busybox", "-o", "json"); ko.Success {
 		busyboxPodName = ko.FirstPodName()
-		util.PrettyPrintOk(os.Stdout, "Grab BusyBox pod name")
+		util.PrettyPrintOk(out, "Grab BusyBox pod name")
 	} else {
 		busyboxPodName = ""
-		util.PrettyPrintErr(os.Stdout, "Grab BusyBox pod name")
+		util.PrettyPrintErr(out, "Grab BusyBox pod name")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
 	// Check connectivity between pods (using busybox)
 	if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", serviceIP); busyboxPodName == "" || ko.Success {
-		util.PrettyPrintOk(os.Stdout, "Accessed Nginx service at "+serviceIP+" from BusyBox")
+		util.PrettyPrintOk(out, "Accessed Nginx service at "+serviceIP+" from BusyBox")
 	} else {
-		util.PrettyPrintErr(os.Stdout, "Accessed Nginx service at "+serviceIP+" from BusyBox")
+		util.PrettyPrintErr(out, "Accessed Nginx service at "+serviceIP+" from BusyBox")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 	if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", ngServiceName); busyboxPodName == "" || ko.Success {
-		util.PrettyPrintOk(os.Stdout, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
+		util.PrettyPrintOk(out, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
 	} else {
-		util.PrettyPrintErr(os.Stdout, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
+		util.PrettyPrintErr(out, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
+		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
 	for _, podIP := range podIPs {
 		if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", podIP); busyboxPodName == "" || ko.Success {
-			util.PrettyPrintOk(os.Stdout, "Accessed Nginx pod at "+podIP+" from BusyBox")
+			util.PrettyPrintOk(out, "Accessed Nginx pod at "+podIP+" from BusyBox")
 		} else {
-			util.PrettyPrintErr(os.Stdout, "Accessed Nginx pod at "+podIP+" from BusyBox")
+			util.PrettyPrintErr(out, "Accessed Nginx pod at "+podIP+" from BusyBox")
+			printFailureDetail(out, ko.CombinedOut)
 			success = false
 		}
 	}
 
 	// Check connectivity with internet
 	if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", "Google.com"); busyboxPodName == "" || ko.Success {
-		util.PrettyPrintOk(os.Stdout, "Accessed Google.com from BusyBox")
+		util.PrettyPrintOk(out, "Accessed Google.com from BusyBox")
 	} else {
-		util.PrettyPrintErrorIgnored(os.Stdout, "Accessed Google.com from BusyBox")
+		util.PrettyPrintErrorIgnored(out, "Accessed Google.com from BusyBox")
 	}
 
 	// Check connectivity from current machine (using curl or wget)
 	// Set Timeout or it could wait forever
 	client := http.Client{
-		Timeout: httpTimeoutMillis,
+		Timeout: httpTimeout,
 	}
 	if _, err := client.Get("http://" + ngServiceName); err == nil {
-		util.PrettyPrintOk(os.Stdout, "Accessed Nginx service via DNS "+ngServiceName+" from this node")
+		util.PrettyPrintOk(out, "Accessed Nginx service via DNS "+ngServiceName+" from this node")
 	} else {
-		util.PrettyPrintErrorIgnored(os.Stdout, "Accessed Nginx service via DNS "+ngServiceName+" from this node")
+		util.PrettyPrintErrorIgnored(out, "Accessed Nginx service via DNS "+ngServiceName+" from this node")
 	}
 	for _, podIP := range podIPs {
 		if _, err := client.Get("http://" + podIP); err == nil {
-			util.PrettyPrintOk(os.Stdout, "Accessed Nginx pod at "+podIP+" from this node")
+			util.PrettyPrintOk(out, "Accessed Nginx pod at "+podIP+" from this node")
 		} else {
-			util.PrettyPrintErrorIgnored(os.Stdout, "Accessed Nginx pod at "+podIP+" from this node")
+			util.PrettyPrintErrorIgnored(out, "Accessed Nginx pod at "+podIP+" from this node")
 		}
 	}
 	if _, err := client.Get("http://google.com/"); err == nil {
-		util.PrettyPrintOk(os.Stdout, "Accessed Google.com from this node")
+		util.PrettyPrintOk(out, "Accessed Google.com from this node")
 	} else {
-		util.PrettyPrintErrorIgnored(os.Stdout, "Accessed Google.com from this node")
+		util.PrettyPrintErrorIgnored(out, "Accessed Google.com from this node")
 	}
 
 	powerDown(ngServiceName)
@@ -161,7 +171,7 @@ func precheckKubectl() bool {
 	ret := true
 	if ko := RunKubectl("version"); !ko.Success {
 		util.PrettyPrintErr(os.Stdout, "Configured kubectl exists")
-		fmt.Fprintf(os.Stdout, "---\n%v\n---\n", ko.CombinedOut)
+		printFailureDetail(os.Stdout, ko.CombinedOut)
 		ret = false
 	} else {
 		util.PrettyPrintOk(os.Stdout, "Configured kubectl exists")
@@ -173,6 +183,7 @@ func precheckServices(nginxServiceName string) bool {
 	ret := true
 	if ko := RunGetService(nginxServiceName); ko.Success {
 		util.PrettyPrintErr(os.Stdout, "Nginx service does not already exist")
+		printFailureDetail(os.Stdout, ko.CombinedOut)
 		ret = false
 	} else {
 		util.PrettyPrintOk(os.Stdout, "Nginx service does not already exist")
@@ -184,12 +195,14 @@ func precheckDeployments() bool {
 	ret := true
 	if ko := RunGetDeployment(bbDeploymentName); ko.Success {
 		util.PrettyPrintErr(os.Stdout, "BusyBox service does not already exist")
+		printFailureDetail(os.Stdout, ko.CombinedOut)
 		ret = false
 	} else {
 		util.PrettyPrintOk(os.Stdout, "BusyBox service does not already exist")
 	}
 	if ko := RunGetDeployment(ngDeploymentName); ko.Success {
 		util.PrettyPrintErr(os.Stdout, "Nginx service does not already exist")
+		printFailureDetail(os.Stdout, ko.CombinedOut)
 		ret = false
 	} else {
 		util.PrettyPrintOk(os.Stdout, "Nginx service does not already exist")
@@ -200,7 +213,12 @@ func precheckDeployments() bool {
 func precheckNamespace() bool {
 	ret := true
 	if config.Namespace != "" {
-		if ko := RunGetNamespace(config.Namespace); !ko.Success || ko.NamespaceStatus() != "Active" {
+		ko := RunGetNamespace(config.Namespace)
+		if !ko.Success {
+			util.PrettyPrintErr(os.Stdout, "Configured kubernetes namespace `"+config.Namespace+"` exists")
+			printFailureDetail(os.Stdout, ko.CombinedOut)
+			ret = false
+		} else if ko.NamespaceStatus() != "Active" {
 			util.PrettyPrintErr(os.Stdout, "Configured kubernetes namespace `"+config.Namespace+"` exists")
 			ret = false
 		} else {
@@ -212,10 +230,16 @@ func precheckNamespace() bool {
 
 func checkDeployments(busbyboxCount, nginxCount int64) bool {
 	ret := true
-	if ko := RunGetDeployment(bbDeploymentName); !ko.Success || ko.ObservedReplicaCount() != busbyboxCount {
+	ko := RunGetDeployment(bbDeploymentName)
+	if !ko.Success {
+		ret = false
+	} else if ko.ObservedReplicaCount() != busbyboxCount {
 		ret = false
 	}
-	if ko := RunGetDeployment(ngDeploymentName); !ko.Success || ko.ObservedReplicaCount() != nginxCount {
+	ko = RunGetDeployment(ngDeploymentName)
+	if !ko.Success {
+		ret = false
+	} else if ko.ObservedReplicaCount() != nginxCount {
 		ret = false
 	}
 	return ret
@@ -239,22 +263,31 @@ func powerDown(nginxServiceName string) {
 		util.PrettyPrintOk(os.Stdout, "Powered down Nginx service")
 	} else {
 		util.PrettyPrintErr(os.Stdout, "Powered down Nginx service")
+		printFailureDetail(os.Stdout, ko.CombinedOut)
 	}
 	// Power down bb
 	if ko := RunKubectl("delete", "deployments", bbDeploymentName); ko.Success {
 		util.PrettyPrintOk(os.Stdout, "Powered down Busybox deployment")
 	} else {
 		util.PrettyPrintErr(os.Stdout, "Powered down Busybox deployment")
+		printFailureDetail(os.Stdout, ko.CombinedOut)
 	}
 	// Power down nginx
 	if ko := RunKubectl("delete", "deployments", ngDeploymentName); ko.Success {
 		util.PrettyPrintOk(os.Stdout, "Powered down Nginx deployment")
 	} else {
 		util.PrettyPrintErr(os.Stdout, "Powered down Nginx deployment")
-		fmt.Fprintf(os.Stdout, "---\n%s---\n", ko.CombinedOut)
+		printFailureDetail(os.Stdout, ko.CombinedOut)
 	}
 }
 
 func nginxServiceName() string {
 	return fmt.Sprintf("%s-%d", runPrefix+"nginx", time.Now().UnixNano())
+}
+
+func printFailureDetail(out io.Writer, detail string) {
+	fmt.Fprintln(out, "-------- OUTPUT --------")
+	fmt.Fprintf(out, detail)
+	fmt.Fprintln(out, "------------------------")
+	fmt.Fprintln(out)
 }

--- a/pkg/kuberang/mainworkflow_test.go
+++ b/pkg/kuberang/mainworkflow_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTimeout(t *testing.T) {
 	client := http.Client{
-		Timeout: httpTimeoutMillis,
+		Timeout: httpTimeout,
 	}
 	// Simulate a timeout using httpbin.org
 	if _, err := client.Get("http://httpbin.org/delay/2"); err == nil {

--- a/pkg/kuberang/mainworkflow_test.go
+++ b/pkg/kuberang/mainworkflow_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTimeout(t *testing.T) {
 	client := http.Client{
-		Timeout: HTTP_Timeout,
+		Timeout: httpTimeoutMillis,
 	}
 	// Simulate a timeout using httpbin.org
 	if _, err := client.Get("http://httpbin.org/delay/2"); err == nil {


### PR DESCRIPTION
We experience intermittent kuberang failures in our test suite, but we are unable to identify the underlying cause. 

With this PR, kuberang prints the error information when there is a failure. This will help us identify the flaky test failures, and also help user in diagnosing a failed smoke test.