### PR TITLE
Add retries to some of the opeartions

### DIFF
--- a/pkg/kuberang/mainworkflow.go
+++ b/pkg/kuberang/mainworkflow.go
@@ -14,142 +14,132 @@ import (
 )
 
 const (
-	runPrefix                = "kuberang-"
-	bbDeploymentName         = runPrefix + "busybox"
-	ngDeploymentName         = runPrefix + "nginx"
-	deploymentTimeoutSeconds = 300 * time.Second
-	httpTimeout              = 1000 * time.Millisecond
+	runPrefix         = "kuberang-"
+	bbDeploymentName  = runPrefix + "busybox"
+	ngDeploymentName  = runPrefix + "nginx"
+	deploymentTimeout = 300 * time.Second
+	httpTimeout       = 1000 * time.Millisecond
 )
 
+// CheckKubernetes runs checks against a cluster. It expects to find
+// a configured `kubectl` binary in the path.
 func CheckKubernetes(skipCleanup bool) error {
 	out := os.Stdout
 	ngServiceName := nginxServiceName()
-	if !precheckKubectl() ||
-		!precheckNamespace() ||
-		!precheckServices(ngServiceName) ||
-		!precheckDeployments() {
-		powerDown(ngServiceName)
-		return errors.New("Pre-conditions failed; must clean up before we can smoke test")
-	}
-
 	success := true
 	registryURL := ""
 	if config.RegistryURL != "" {
 		registryURL = config.RegistryURL + "/"
 	}
 
-	// Scale out busybox
-	busyboxCount := int64(1)
-	if ko := RunKubectl("run", bbDeploymentName, fmt.Sprintf("--image=%sbusybox:latest", registryURL), "--image-pull-policy=IfNotPresent", "--", "sleep", "3600"); !ko.Success {
-		util.PrettyPrintErr(out, "Issued BusyBox start request")
-		printFailureDetail(out, ko.CombinedOut)
-		success = false
-	} else {
-		util.PrettyPrintOk(out, "Issued BusyBox start request")
-	}
-	// Scale out nginx
-	// Try to run a Pod on each Node,
-	// This scheduling is not guaranteed but it gets close
-	nginxCount := int64(RunGetNodes().NodeCount())
-	if ko := RunPod(ngDeploymentName, fmt.Sprintf("%snginx:stable-alpine", registryURL), nginxCount); !ko.Success {
-		util.PrettyPrintErr(out, "Issued Nginx start request")
-		printFailureDetail(out, ko.CombinedOut)
-		success = false
-	} else {
-		util.PrettyPrintOk(out, "Issued Nginx start request")
+	// Make sure we have all we need
+	// Quit if we find existing kuberang deployments on the cluster
+	if !checkPreconditions(ngServiceName) {
+		return errors.New("Pre-conditions failed")
 	}
 
-	// Check for both
-	if !waitForDeployments(busyboxCount, nginxCount) {
-		return nil
+	if !skipCleanup {
+		defer powerDown(ngServiceName)
 	}
 
-	// Add service
-	if ko := RunKubectl("expose", "deployment", ngDeploymentName, "--name="+ngServiceName, "--port=80"); !ko.Success {
-		util.PrettyPrintErr(out, "Issued expose Nginx service request")
-		printFailureDetail(out, ko.CombinedOut)
-		success = false
-	} else {
-		util.PrettyPrintOk(out, "Issued expose Nginx service request")
+	// Deploy the workloads required for running checks
+	if !deployTestWorkloads(registryURL, out, ngServiceName) {
+		return errors.New("Failed to deploy test workloads")
 	}
 
-	// Get pod & service IPs
-	var podIPs []string
-	var serviceIP string
-	var busyboxPodName string
+	// Get IPs of all nginx pods
+	podIPs := []string{}
 	if ko := RunKubectl("get", "pods", "-l", "run=kuberang-nginx", "-o", "json"); ko.Success {
 		podIPs = ko.PodIPs()
 		util.PrettyPrintOk(out, "Grab nginx pod ip addresses")
 	} else {
-		podIPs = make([]string, 0)
 		util.PrettyPrintErr(out, "Grab nginx pod ip addresses")
 		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
+	// Get the service IP of the nginx service
+	var serviceIP string
 	if ko := RunGetService(ngServiceName); ko.Success {
 		serviceIP = ko.ServiceCluserIP()
 		util.PrettyPrintOk(out, "Grab nginx service ip address")
 	} else {
-		serviceIP = ""
 		util.PrettyPrintErr(out, "Grab nginx service ip address")
 		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
+	// Get the name of the busybox pod
+	var busyboxPodName string
 	if ko := RunKubectl("get", "pods", "-l", "run=kuberang-busybox", "-o", "json"); ko.Success {
 		busyboxPodName = ko.FirstPodName()
 		util.PrettyPrintOk(out, "Grab BusyBox pod name")
 	} else {
-		busyboxPodName = ""
 		util.PrettyPrintErr(out, "Grab BusyBox pod name")
 		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
-	// Check connectivity between pods (using busybox)
-	if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", serviceIP); busyboxPodName == "" || ko.Success {
+	// Gate on successful acquisition of all the required names / IPs
+	if !success {
+		return errors.New("Failed to get required information from cluster")
+	}
+
+	// The following checks verify the pod network and the ability for
+	// pods to talk to each other.
+	// 1. Access nginx service via service IP from another pod
+	var kubeOut KubeOutput
+	ok := retry(3, func() bool {
+		kubeOut = RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", serviceIP)
+		return kubeOut.Success
+	})
+	if ok {
 		util.PrettyPrintOk(out, "Accessed Nginx service at "+serviceIP+" from BusyBox")
 	} else {
+		printFailureDetail(out, kubeOut.CombinedOut)
 		util.PrettyPrintErr(out, "Accessed Nginx service at "+serviceIP+" from BusyBox")
-		printFailureDetail(out, ko.CombinedOut)
-		success = false
-	}
-	if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", ngServiceName); busyboxPodName == "" || ko.Success {
-		util.PrettyPrintOk(out, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
-	} else {
-		util.PrettyPrintErr(out, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
-		printFailureDetail(out, ko.CombinedOut)
 		success = false
 	}
 
+	// 2. Access nginx service via service name (DNS) from another pod
+	ok = retry(3, func() bool {
+		kubeOut = RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", ngServiceName)
+		return kubeOut.Success
+	})
+	if ok {
+		util.PrettyPrintOk(out, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
+	} else {
+		util.PrettyPrintErr(out, "Accessed Nginx service via DNS "+ngServiceName+" from BusyBox")
+		printFailureDetail(out, kubeOut.CombinedOut)
+		success = false
+	}
+
+	// 3. Access all nginx pods by IP
 	for _, podIP := range podIPs {
-		if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", podIP); busyboxPodName == "" || ko.Success {
+		ok = retry(3, func() bool {
+			kubeOut = RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", podIP)
+			return kubeOut.Success
+		})
+		if ok {
 			util.PrettyPrintOk(out, "Accessed Nginx pod at "+podIP+" from BusyBox")
 		} else {
 			util.PrettyPrintErr(out, "Accessed Nginx pod at "+podIP+" from BusyBox")
-			printFailureDetail(out, ko.CombinedOut)
+			printFailureDetail(out, kubeOut.CombinedOut)
 			success = false
 		}
 	}
 
-	// Check connectivity with internet
+	// 4. Check internet connectivity from pod
 	if ko := RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", "Google.com"); busyboxPodName == "" || ko.Success {
 		util.PrettyPrintOk(out, "Accessed Google.com from BusyBox")
 	} else {
 		util.PrettyPrintErrorIgnored(out, "Accessed Google.com from BusyBox")
 	}
 
-	// Check connectivity from current machine (using curl or wget)
-	// Set Timeout or it could wait forever
 	client := http.Client{
 		Timeout: httpTimeout,
 	}
-	if _, err := client.Get("http://" + ngServiceName); err == nil {
-		util.PrettyPrintOk(out, "Accessed Nginx service via DNS "+ngServiceName+" from this node")
-	} else {
-		util.PrettyPrintErrorIgnored(out, "Accessed Nginx service via DNS "+ngServiceName+" from this node")
-	}
+	// 5. Check connectivity from current machine to all nginx pods
 	for _, podIP := range podIPs {
 		if _, err := client.Get("http://" + podIP); err == nil {
 			util.PrettyPrintOk(out, "Accessed Nginx pod at "+podIP+" from this node")
@@ -157,44 +147,87 @@ func CheckKubernetes(skipCleanup bool) error {
 			util.PrettyPrintErrorIgnored(out, "Accessed Nginx pod at "+podIP+" from this node")
 		}
 	}
+
+	// 6. Check internet connectivity from current machine
 	if _, err := client.Get("http://google.com/"); err == nil {
 		util.PrettyPrintOk(out, "Accessed Google.com from this node")
 	} else {
 		util.PrettyPrintErrorIgnored(out, "Accessed Google.com from this node")
 	}
 
-	if !skipCleanup {
-		powerDown(ngServiceName)
+	if !success {
+		return errors.New("One or more required steps failed")
 	}
+	return nil
+}
 
-	if success {
-		return nil
+func deployTestWorkloads(registryURL string, out io.Writer, ngServiceName string) bool {
+	// Scale out busybox
+	busyboxCount := int64(1)
+	if ko := RunKubectl("run", bbDeploymentName, fmt.Sprintf("--image=%sbusybox:latest", registryURL), "--image-pull-policy=IfNotPresent", "--", "sleep", "3600"); !ko.Success {
+		util.PrettyPrintErr(out, "Issued BusyBox start request")
+		printFailureDetail(out, ko.CombinedOut)
+		return false
 	}
-	return errors.New("One or more required steps failed")
+	util.PrettyPrintOk(out, "Issued BusyBox start request")
+
+	// Scale out nginx
+	// Try to run a Pod on each Node,
+	// This scheduling is not guaranteed but it gets close
+	nginxCount := int64(RunGetNodes().NodeCount())
+	if ko := RunPod(ngDeploymentName, fmt.Sprintf("%snginx:stable-alpine", registryURL), nginxCount); !ko.Success {
+		util.PrettyPrintErr(out, "Issued Nginx start request")
+		printFailureDetail(out, ko.CombinedOut)
+		return false
+	}
+	util.PrettyPrintOk(out, "Issued Nginx start request")
+
+	// Add service
+	if ko := RunKubectl("expose", "deployment", ngDeploymentName, "--name="+ngServiceName, "--port=80"); !ko.Success {
+		util.PrettyPrintErr(out, "Issued expose Nginx service request")
+		printFailureDetail(out, ko.CombinedOut)
+		return false
+	}
+	util.PrettyPrintOk(out, "Issued expose Nginx service request")
+
+	// Wait until deployments are ready
+	return waitForDeployments(busyboxCount, nginxCount)
+}
+
+func checkPreconditions(nginxServiceName string) bool {
+	ok := true
+	if !precheckKubectl() {
+		return false // don't bother doing anything if kubectl isn't configured
+	}
+	if !precheckNamespace() {
+		ok = false
+	}
+	if !precheckServices(nginxServiceName) {
+		ok = false
+	}
+	if !precheckDeployments() {
+		ok = false
+	}
+	return ok
 }
 
 func precheckKubectl() bool {
-	ret := true
 	if ko := RunKubectl("version"); !ko.Success {
 		util.PrettyPrintErr(os.Stdout, "Configured kubectl exists")
 		printFailureDetail(os.Stdout, ko.CombinedOut)
-		ret = false
-	} else {
-		util.PrettyPrintOk(os.Stdout, "Configured kubectl exists")
+		return false
 	}
-	return ret
+	return true
 }
 
 func precheckServices(nginxServiceName string) bool {
-	ret := true
 	if ko := RunGetService(nginxServiceName); ko.Success {
 		util.PrettyPrintErr(os.Stdout, "Nginx service does not already exist")
 		printFailureDetail(os.Stdout, ko.CombinedOut)
-		ret = false
-	} else {
-		util.PrettyPrintOk(os.Stdout, "Nginx service does not already exist")
+		return false
 	}
-	return ret
+	util.PrettyPrintOk(os.Stdout, "Nginx service does not already exist")
+	return true
 }
 
 func precheckDeployments() bool {
@@ -253,7 +286,7 @@ func checkDeployments(busyboxCount, nginxCount int64) bool {
 
 func waitForDeployments(busyboxCount, nginxCount int64) bool {
 	start := time.Now()
-	for time.Since(start) < deploymentTimeoutSeconds {
+	for time.Since(start) < deploymentTimeout {
 		if checkDeployments(busyboxCount, nginxCount) {
 			util.PrettyPrintOk(os.Stdout, "Both deployments completed successfully within timeout")
 			return true

--- a/pkg/kuberang/retry.go
+++ b/pkg/kuberang/retry.go
@@ -1,0 +1,15 @@
+package kuberang
+
+import "time"
+
+func retry(times int, f func() bool) bool {
+	attempt := 0
+	for attempt < times {
+		if ok := f(); ok {
+			return true
+		}
+		time.Sleep(1 * time.Second)
+		attempt++
+	}
+	return false
+}


### PR DESCRIPTION
During kismatic integration tests, we observe intermittent networking-related failures. 

This PR adds retries around the operations that we have seen fail intermittently. 