### PR TITLE
Doubling retry time for DNS check

### DIFF
--- a/pkg/kuberang/mainworkflow.go
+++ b/pkg/kuberang/mainworkflow.go
@@ -102,7 +102,7 @@ func CheckKubernetes(skipCleanup bool) error {
 	}
 
 	// 2. Access nginx service via service name (DNS) from another pod
-	ok = retry(3, func() bool {
+	ok = retry(6, func() bool {
 		kubeOut = RunKubectl("exec", busyboxPodName, "--", "wget", "-qO-", ngServiceName)
 		return kubeOut.Success
 	})


### PR DESCRIPTION
Kuberang fails intermittently when performing the DNS check. Increasing the number of retries as it seems to be timing/network flakiness.