### PR TITLE
Add kubernetes service validation

### DIFF
--- a/pkg/kuberang/mainworkflow.go
+++ b/pkg/kuberang/mainworkflow.go
@@ -155,6 +155,15 @@ func CheckKubernetes(skipCleanup bool) error {
 		util.PrettyPrintErrorIgnored(out, "Accessed Google.com from this node")
 	}
 
+	// 7. Verify that the busybox pod is able to ping an API server via the kubernetes service
+	if ko := RunKubectl("exec", busyboxPodName, "--", "ping", "-c", "5", "kubernetes"); busyboxPodName == "" || ko.Success {
+		util.PrettyPrintOk(out, "Ping kubernetes service from BusyBox")
+	} else {
+		util.PrettyPrintErr(out, "Ping kubernetes service from BusyBox")
+		printFailureDetail(out, ko.CombinedOut)
+		success = false
+	}
+
 	if !success {
 		return errors.New("One or more required steps failed")
 	}


### PR DESCRIPTION
Pods should be able to reach the API server via the kubernetes
service. We use ping to verify this instead of curl or wget
as an initial implementation, but using wget with service accounts
might be an improvement.