### PR TITLE
Add flag to ignore pod IP accessibility check

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -26,7 +26,7 @@ func NewKuberangCommand(version string, in io.Reader, out io.Writer) *cobra.Comm
 		"Override the default Docker Hub URL to use a local offline registry for required Docker images.")
 	cmd.Flags().BoolVar(&config.SkipCleanup, "skip-cleanup", false, "Don't clean up. Leave all deployed artifacts running on the cluster.")
 	cmd.Flags().BoolVar(&config.SkipDNSTests, "skip-dns-tests", false, "Don't test kubernetes DNS if none is deployed.")
-
+	cmd.Flags().BoolVar(&config.IgnorePodIPAccessibilityCheck, "ignore-pod-ip-accessibility-check", false, "Don't fail the smoke test if the pod IP accessibility check fails.")
 	cmd.AddCommand(NewCmdVersion(out))
 
 	return cmd

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,15 @@
 package config
 
 var (
-	Namespace    string
-	RegistryURL  string
-	SkipCleanup  bool
+	// Namespace where the kuberang tests will be executed
+	Namespace string
+	// RegistryURL to be used for downloading the container images used in the smoke test
+	RegistryURL string
+	// SkipCleanup determines whether the workloads should be cleaned up after the test
+	SkipCleanup bool
+	// SkipDNSTests determines whether the DNS tests should be performed
 	SkipDNSTests bool
+	// IgnorePodIPAccessibilityCheck determines whether a failed pod IP accessibility check
+	// should fail the smoke test as a whole
+	IgnorePodIPAccessibilityCheck bool
 )

--- a/pkg/kuberang/mainworkflow.go
+++ b/pkg/kuberang/mainworkflow.go
@@ -171,6 +171,8 @@ func CheckKubernetes() error {
 		})
 		if ok {
 			util.PrettyPrintOk(out, "Accessed Nginx pod at "+podIP+" from BusyBox")
+		} else if config.IgnorePodIPAccessibilityCheck {
+			util.PrettyPrintErrorIgnored(out, "Accessed Nginx pod at "+podIP+" from BusyBox")
 		} else {
 			util.PrettyPrintErr(out, "Accessed Nginx pod at "+podIP+" from BusyBox")
 			printFailureDetail(out, kubeOut.CombinedOut)


### PR DESCRIPTION
This is required because contiv does not support accessing pods directly
via the pod IP when they are exposed as a service.