### PR TITLE
Increase retries and backoff when getting nginx pod IPs

### DIFF
--- a/pkg/kuberang/mainworkflow.go
+++ b/pkg/kuberang/mainworkflow.go
@@ -60,9 +60,11 @@ func CheckKubernetes() error {
 	}
 
 	// Get IPs of all nginx pods
+	// Use a backoff retry as we have seen many cases where one of the pods
+	// fails, and we have to wait for the replicaset to deploy a new one.
 	podIPs := []string{}
 	var ko KubeOutput
-	ok := retry(3, func() bool {
+	ok := retryWithBackoff(5, func() bool {
 		if ko = RunKubectl("get", "pods", "-l", "run=kuberang-nginx", "-o", "json"); ko.Success {
 			podIPs = ko.PodIPs()
 			// check for at least one pod IP

--- a/pkg/kuberang/retry.go
+++ b/pkg/kuberang/retry.go
@@ -13,3 +13,15 @@ func retry(times int, f func() bool) bool {
 	}
 	return false
 }
+
+func retryWithBackoff(times uint, f func() bool) bool {
+	var attempt uint
+	for attempt < times {
+		if ok := f(); ok {
+			return true
+		}
+		time.Sleep((1 << attempt) * time.Second)
+		attempt++
+	}
+	return false
+}


### PR DESCRIPTION
We have seen cases where one of the nginx pods enters an unready state, and there is not enough time for a new pod or container to start up. 

For this reason, I suggest we increase the number of retries we perform when getting the nginx pod IPs.