### PR TITLE
Use labels to select the test resources

### DIFF
--- a/pkg/kuberang/kubectlparser.go
+++ b/pkg/kuberang/kubectlparser.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"strconv"
 
 	"github.com/apprenda/kuberang/pkg/config"
 )
@@ -40,20 +39,12 @@ func RunGetService(svcName string) KubeOutput {
 	return RunKubectl("get", "service", svcName, "-o", "json")
 }
 
-func RunGetPodByImage(name string) KubeOutput {
-	return RunKubectl("get", "deployment", name, "-o", "json")
-}
-
 func RunGetDeployment(name string) KubeOutput {
 	return RunKubectl("get", "deployment", name, "-o", "json")
 }
 
 func RunGetNamespace(name string) KubeOutput {
 	return RunKubectl("get", "namespace", name, "-o", "json")
-}
-
-func RunPod(name string, image string, count int64) KubeOutput {
-	return RunKubectl("run", name, "--image="+image, "--image-pull-policy=IfNotPresent", "--replicas="+strconv.FormatInt(count, 10), "-o", "json")
 }
 
 func RunGetNodes() KubeOutput {


### PR DESCRIPTION
We have always noticed intermittent kuberang issues during integration tests. This is caused due to the way kuberang selects pods by name. When running kuberang on multiple masters kuberang will try to fetch the podIP of a terminating pod or try to use a terminating busybox.

This PR addresses this by using label selectors instead. 